### PR TITLE
Fix/media link validation #58

### DIFF
--- a/src/links.js
+++ b/src/links.js
@@ -12,6 +12,7 @@ let results;
 let distSitePath = "";
 
 const links = module.exports;
+const mediaFolder = '/media';
 
 links.validate = function (conf) {
     validPaths = new Set();
@@ -53,7 +54,17 @@ function getLinks(files) {
     for (let file of files) {
         let $ = cheerio.load(fs.readFileSync(file));
         $('#presidium-content').find('section a').each(function (i, link) {
-            links.add($(link).attr('href'))
+
+            let href = $(link).attr('href');
+            if (typeof href !== 'undefined'){
+                // Checks if the href belongs to a set of assets (/media folder)
+                if (href.indexOf(mediaFolder) > -1){
+                    let parsedLink = url.parse(href);
+                    href = parsedLink.pathname;     // Remove the hash from the URL
+                }
+
+                links.add(href)
+            }
         });
     }
     return links;
@@ -117,7 +128,10 @@ function validateLinks(baseUrl) {
                     log('broken', baseLink)
                 }
             } else {
-                if (link.lastIndexOf('/') === link.length - 1 && validPaths.has(link)) {
+                if (
+                    (link.lastIndexOf('/') === link.length - 1 && validPaths.has(link)) ||
+                    (link.lastIndexOf(mediaFolder) > -1 && fs.existsSync(distSitePath + link))
+                ) {
                     log('valid', baseLink)
                 } else {
                     if (validPaths.has(link + '/')) {

--- a/src/links.js
+++ b/src/links.js
@@ -79,7 +79,7 @@ function anchorValid(dir, anchorLink) {
     if (validPaths.has(file)) {
         let $ = cheerio.load(fs.readFileSync(dir + file + 'index.html'));
 
-        return $('.anchor' + link.hash).length > 0;
+        return $('.anchor' + '[id="'+link.hash.slice(1)+'"]').length > 0;
     } else return false
 }
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -47,7 +47,7 @@ describe('Link Validation', () => {
     });
 
     it('Should indicate valid links', () => {
-        assert.equal(res.valid, 5);
+        assert.equal(res.valid, 6);
     });
 
     it('Should indicate external links', () => {

--- a/test/validation/content/_recipes/07-links/links.md
+++ b/test/validation/content/_recipes/07-links/links.md
@@ -34,3 +34,5 @@ Links (found below) will be used to test if our link checker works
 [Link 11]()
 
 [Link 12](http://www.spandigital.com)
+
+[Link 12]({{site.baseurl}}/media/js/presidium.js)


### PR DESCRIPTION
Improves the link validation:
- Fix cheerio selector to analyze id names that contains dot
- Ignores hashes on media links