### PR TITLE
#133 | Added support for --config argument when running npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "shelljs": "^0.7.7",
     "slug": "^0.9.1",
     "strip-markdown": "^3.0.0",
-    "yargs": "^7.0.2"
+    "yargs": "^7.1.0"
   },
   "devDependencies": {
     "mocha": "^3.2.0"

--- a/src/presidium.js
+++ b/src/presidium.js
@@ -7,6 +7,7 @@ var links = require('./links');
 var linter = require('./linter');
 var yaml = require('js-yaml');
 var version = require('./version');
+const argv = require('yargs').argv;
 
 var presidium = module.exports;
 
@@ -66,10 +67,11 @@ presidium.generate = function(conf) {
 };
 
 presidium.build = function(conf) {
+    let extraConf =  argv.config ? `,${argv.config}` : '';
     console.log(`Building site...`);
     const pwd = shell.pwd();
     shell.cd(conf.jekyllPath);
-    const cmd = `bundle exec jekyll build --config ../${path.join(conf.distSrcPath, '_config.yml')} --trace -s ../${conf.distSrcPath} -d ../${conf.distSitePath}`;
+    const cmd = `bundle exec jekyll build --config ../${path.join(conf.distSrcPath, '_config.yml')}${extraConf} --trace -s ../${conf.distSrcPath} -d ../${conf.distSitePath}`;
 
     console.log(`Executing: ${cmd}`);
     shell.exec(cmd);

--- a/src/presidium.js
+++ b/src/presidium.js
@@ -67,7 +67,17 @@ presidium.generate = function(conf) {
 };
 
 presidium.build = function(conf) {
-    let extraConf =  argv.config ? `,${argv.config}` : '';
+    // Manage extra config files
+    const configFiles = `${argv.config}`;
+    let extraConf = '';
+    if (argv.config) {
+        extraConf = configFiles.split(',').map( x => {
+            x = path.isAbsolute(x) ? x : `../${x}`;
+            return x;
+        });
+    }
+    extraConf =  extraConf ? `,${extraConf}` : '';
+
     console.log(`Building site...`);
     const pwd = shell.pwd();
     shell.cd(conf.jekyllPath);


### PR DESCRIPTION
This PR allows to add `--config` argument to `npm run build` to support multiple configuration files. 
Usage:
- `npm run build -- --config <MyFilePath> [--config <MySecondFilePath>, --config...]`
- `npm run build -- --config <MyFilePath>[,<MySecondFilePath>...]`

Where config path can be relative to the root of the project or absolute paths.