### PR TITLE
SPP 744 Use title for collection if it is not set for external-url

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -27,7 +27,7 @@ parse.section = function(conf, section) {
 		newTab =
 			section['external-url']['new-tab'] !== undefined ? section['external-url']['new-tab'] : true;
 		// Use title for collection if it's not set
-		if (collection === undefined) {
+		if (!collection) {
 		  collection = section.title
     }
 	} else {
@@ -43,7 +43,7 @@ parse.section = function(conf, section) {
         title: section.title,
         path: sectionPath,
         url: sectionUrl,
-        collection: collection,
+        collection,
         collapsed: section.collapsed || false,
         newTab: newTab,
         exportArticles: section['export-articles'] || false,

--- a/src/parse.js
+++ b/src/parse.js
@@ -20,16 +20,22 @@ parse.section = function(conf, section) {
 	let sectionUrl;
 	let newTab;
 
+	let collection = section.collection;
+
 	if (section['external-url'] !== undefined) {
 		sectionUrl = section['external-url'].href;
 		newTab =
 			section['external-url']['new-tab'] !== undefined ? section['external-url']['new-tab'] : true;
+		// Use title for collection if it's not set
+		if (collection === undefined) {
+		  collection = section.title
+    }
 	} else {
 		sectionUrl = path.join(conf.baseUrl, section.url);
 		newTab = false;
 	}
 
-	const sectionPath = path.join(conf.contentPath, `_${section.collection}`, '/');
+	const sectionPath = path.join(conf.contentPath, `_${collection}`, '/');
 
     return {
         id: sectionPath,
@@ -37,7 +43,7 @@ parse.section = function(conf, section) {
         title: section.title,
         path: sectionPath,
         url: sectionUrl,
-        collection: section.collection,
+        collection: collection,
         collapsed: section.collapsed || false,
         newTab: newTab,
         exportArticles: section['export-articles'] || false,

--- a/test/validation.js
+++ b/test/validation.js
@@ -4,6 +4,7 @@ const it = mocha.it;
 
 let config = require('../src/config');
 let links = require('../src/links');
+let structure = require('../src/structure');
 
 let presidium = require('../src/presidium');
 
@@ -27,6 +28,7 @@ describe('Link Validation', () => {
 
 		conf = config.load('./test/validation/_config.yml');
 		res = links.validate(conf);
+		st = structure.generate(conf);
 	});
 
 	it('Should find and validate links', () => {
@@ -53,4 +55,15 @@ describe('Link Validation', () => {
 	it('Should indicate external links', () => {
 		assert.equal(res.external, 1);
 	});
+
+	it('Should have collection set for external link section', () => {
+		for (let section of st.sections) {
+			if (section.title === "External Link") {
+				assert.equal(section.collection, "External Link");
+			}
+			if (section.title === "Another External Link") {
+				assert.equal(section.collection, "Another External Link");
+			}
+		}
+	})
 });

--- a/test/validation/_config.yml
+++ b/test/validation/_config.yml
@@ -42,6 +42,16 @@ sections:
     url: "/recipes/"
     collection: recipes
 
+  - title: External Link
+    external-url:
+      href: "http://www.google.com"
+      new-tab: true
+
+  - title: Another External Link
+    external-url:
+      href: "http://www.yahoo.com"
+      new-tab: false
+
 #
 # Optional filters that may be used to filter articles by role.
 #


### PR DESCRIPTION
When creating a `external-url` in the menu using static href, `collection` is not a required field.
It will be set to the `title` of the section if it's no set in the `_config.yml`.

Added a validation test.