### PR TITLE
Add ability to mark a section as alwaysExpanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "lint": "eslint . --max-warnings=0",
+    "lint": "eslint ./src --max-warnings=0",
     "update-jekyll": "cd .jekyll; bundle lock --update"
   },
   "husky": {

--- a/src/menu.js
+++ b/src/menu.js
@@ -51,6 +51,7 @@ function addSection(node, props) {
 		title: props.title,
 		level: 1,
 		collapsed: props.collapsed,
+		alwaysExpanded: props.alwaysExpanded,
 		newTab: props.newTab,
 		path: props.path,
 		url: props.url,

--- a/src/parse.js
+++ b/src/parse.js
@@ -44,6 +44,7 @@ parse.section = function (conf, section) {
 		path: sectionPath,
 		url: sectionUrl,
 		collection,
+		alwaysExpanded: section['always-expanded'] || false,
 		collapsed: section.collapsed || false,
 		newTab: newTab,
 		exportArticles: section['export-articles'] || false,

--- a/test/menu.js
+++ b/test/menu.js
@@ -1,0 +1,75 @@
+const mocha = require('mocha');
+const describe = mocha.describe;
+const before = mocha.before;
+const it = mocha.it;
+
+const config = require('../src/config');
+const presidium = require('../src/presidium');
+let assert = require('assert');
+let path = require('path');
+let fs = require('fs-extra');
+
+describe('Menu', function() {
+	this.timeout(0);
+	let conf;
+	const distSitePath = './test/menu/dist/site';
+	const distSrcPath = './test/menu/dist/src';
+
+	describe('Menu.json', function() {
+		before(function() {
+			conf = config.load('./test/menu/_config.yml');
+			presidium.clean(conf);
+			presidium.generate(conf);
+			conf.distSrcPath = './menu/dist/src';
+			conf.distSitePath = './menu/dist/site';
+			presidium.build(conf);
+		});
+
+		it('Generated files contain alwaysOpen for menu load', function(done) {
+			const keyConceptsPath = path.join(
+				distSitePath,
+				'key-concepts'
+			);
+			const filePath = path.join(keyConceptsPath, 'index.html');
+			if(!fs.existsSync(filePath)) {
+				assert.fail('index.html file does not exist in key concepts diretory');
+				done();
+			}
+			const file = fs.readFileSync(filePath);
+			if (!file.includes('"alwaysExpanded":true')) {
+				assert.fail('Found no sections with alwaysExpanded set to true');
+				done();
+			}
+			done();
+		});
+
+		it('Menu.json has alwaysOpen set correctly', function(done) {
+			const menuJsonPath = path.join(
+				distSrcPath,
+				'_includes'
+			);
+			const filePath = path.join(menuJsonPath, 'menu.json');
+			if(!fs.existsSync(filePath)) {
+				assert.fail('menu.json file does not exist');
+				done();
+			}
+			const rawData = fs.readFileSync(filePath);
+			let menuData = JSON.parse(rawData);
+			if (!menuData) {
+				assert.fail('Unable to parse json data from menu.json');
+				done();
+			}
+			if (menuData.children ){
+				menuData.children.forEach(value => {
+					if (value.title === 'Key Concepts') {
+						assert.equal(value.alwaysExpanded, false);
+					}
+					if (value.title === 'Internal Section') {
+						assert.equal(value.alwaysExpanded, true);
+					}
+				});
+			}
+			done();
+		});
+	});
+});

--- a/test/menu/_config.yml
+++ b/test/menu/_config.yml
@@ -1,0 +1,95 @@
+#
+# Site Metadata
+#
+# - name: Site name
+# _ baseurl: Optional URL to use where documentation is hosted in a subdirectory `domain.com/{baseurl}`
+# - footer: Footer copy
+# - logo: Menu bar logo
+# - show: Hide or show article components. Defaults to true
+# - external: Links to external sources
+#
+name: Presidium
+baseurl: /presidium
+footer: SPAN Digital
+logo: media/images/logo.png
+show:
+  status: true
+  author: true
+external:
+  authors-url: https://github.com/orgs/SPANDigital/people/
+
+jekyll-path: ./test/.jekyll
+core-path: ./
+content-path:  ./test/menu/content/
+media-path:  ./test/menu/media/
+dist-path: ./test/menu/dist/
+
+#
+# Menu Structure
+#
+# - tile: Menu item title
+# - path: Path to generated article collection
+# - collection: The collection to use for generating a sub menu of articles (REQUIRED).
+#
+sections:
+  - title: "Key Concepts"
+    url: "/key-concepts/"
+    collection: key-concepts
+
+  - title: "Internal Section"
+    url: "/internal-section/"
+    collection: internal-section
+    always-expanded: true
+
+  - title: "Both Section"
+    url: "/both-section/"
+    collection: both-section
+#
+# Optional filters that may be used to filter articles by role.
+#
+roles:
+  label: "Show documentation for"
+  all: "All Roles"
+  options:
+    - "Business Analyst"
+    - "Developer"
+    - "Tester"
+
+#
+# Optional flag to specify whether article scope (internal/external) is respected.
+# Defaults to `false` if not included
+#
+
+#
+# Jekyll collections definitions that use layout templates from presidium-core
+#
+collections:
+    key-concepts:
+    internal-section:
+    both-section:
+
+#
+# Exclude the following files from the generated site
+#
+exclude: [
+    "README.md",
+    "LICENSE",
+    "_TEMPLATE.md",
+    ".gitignore"
+]
+
+#
+# System wide defaults
+#
+defaults:
+    -
+        scope:
+            path: ""
+        values:
+            layout: "container"
+
+#
+# Sass settings
+#
+sass:
+    sass_dir: media/css/_sass

--- a/test/menu/content/_both-section/internal-and-external/both.md
+++ b/test/menu/content/_both-section/internal-and-external/both.md
@@ -1,0 +1,6 @@
+---
+title: Both Scopes
+scope: [internal, external]
+---
+
+Article with both internal and external scope

--- a/test/menu/content/_both-section/internal-and-external/index.md
+++ b/test/menu/content/_both-section/internal-and-external/index.md
@@ -1,0 +1,3 @@
+---
+title: Internal and External
+---

--- a/test/menu/content/_both-section/internal-and-external/unscoped.md
+++ b/test/menu/content/_both-section/internal-and-external/unscoped.md
@@ -1,0 +1,4 @@
+---
+title: Unscoped Article
+---
+Article with no scope

--- a/test/menu/content/_internal-section/index.md
+++ b/test/menu/content/_internal-section/index.md
@@ -1,0 +1,6 @@
+---
+title: Internal Section
+---
+
+Section comprised entirely of internal articles. 
+The articles are not specified as internal, but should inherit from the scope of the section.

--- a/test/menu/content/_internal-section/no-scope.md
+++ b/test/menu/content/_internal-section/no-scope.md
@@ -1,0 +1,5 @@
+---
+title: No Scope
+---
+
+Article with No Scope.

--- a/test/menu/content/_key-concepts/01-scope/01-internal/index.md
+++ b/test/menu/content/_key-concepts/01-scope/01-internal/index.md
@@ -1,0 +1,5 @@
+---
+title: Internal Scope
+scope: internal
+---
+Scope descriptor

--- a/test/menu/content/_key-concepts/01-scope/01-internal/internal.md
+++ b/test/menu/content/_key-concepts/01-scope/01-internal/internal.md
@@ -1,0 +1,9 @@
+---
+title: Internal Article
+scope: internal
+---
+
+Article for `internal` scope:
+```
+scope: internal
+```

--- a/test/menu/content/_key-concepts/01-scope/02-external/all.md
+++ b/test/menu/content/_key-concepts/01-scope/02-external/all.md
@@ -1,0 +1,8 @@
+---
+title: No Scope
+---
+
+Article without specified scope:
+```
+No scope field specified
+```

--- a/test/menu/content/_key-concepts/01-scope/02-external/external.md
+++ b/test/menu/content/_key-concepts/01-scope/02-external/external.md
@@ -1,0 +1,9 @@
+---
+title: External Article
+scope: [external, internal]
+---
+
+Article for `external` scope:
+```
+scope: external
+```

--- a/test/menu/content/_key-concepts/01-scope/02-external/index.md
+++ b/test/menu/content/_key-concepts/01-scope/02-external/index.md
@@ -1,0 +1,5 @@
+---
+title: External Scope
+scope: external
+---
+Scope descriptor

--- a/test/menu/content/_key-concepts/01-scope/02-external/internal.md
+++ b/test/menu/content/_key-concepts/01-scope/02-external/internal.md
@@ -1,0 +1,9 @@
+---
+title: Internal Article
+scope: [internal]
+---
+
+Article for `internal` scope:
+```
+scope: internal
+```

--- a/test/menu/content/_key-concepts/01-scope/index.md
+++ b/test/menu/content/_key-concepts/01-scope/index.md
@@ -1,0 +1,4 @@
+---
+title: Scope Overview
+---
+Scope descriptor

--- a/test/menu/content/_key-concepts/index.md
+++ b/test/menu/content/_key-concepts/index.md
@@ -1,0 +1,4 @@
+---
+title: Key Concepts
+---
+Key concept descriptor

--- a/test/menu/media/css/_sass/_custom.scss
+++ b/test/menu/media/css/_sass/_custom.scss
@@ -1,0 +1,1 @@
+// Custom SASS

--- a/test/menu/media/css/_sass/_variables.scss
+++ b/test/menu/media/css/_sass/_variables.scss
@@ -1,0 +1,5 @@
+@import 'themes/spacelab';
+
+
+
+


### PR DESCRIPTION
SPP-881 | AH-76 | Add ability to mark a section as alwaysExpanded

This is done by adding `always-expanded` to the section:
```
sections:
  - title: "Key Concepts"
    url: "/key-concepts/"
    collection: key-concepts

  - title: "Internal Section"
    url: "/internal-section/"
    collection: internal-section
    always-expanded: true

  - title: "Both Section"
    url: "/both-section/"
    collection: both-section
```

** Also set linter to only check src directory**

Once this is merged, https://github.com/SPANDigital/presidium-js/pull/42 needs to be reviewed