### PR TITLE
ah-97 | add placeholder for article feedback bar

### DIFF
--- a/_includes/article-bar-placeholder.html
+++ b/_includes/article-bar-placeholder.html
@@ -1,0 +1,3 @@
+<div class="placeholder">
+    <div class="article-bar-placeholder"></div>
+</div>

--- a/_includes/article.html
+++ b/_includes/article.html
@@ -27,6 +27,9 @@
     <article>{{ article.content }}</article>
 
     <hr/>
+    {% if site.enterprise.script %}
+        {% include article-bar-placeholder.html %}
+    {% endif %}
     {% endif %}
     {% else %} Article not found: {{article-id}} <hr/> {% endif %}
 </div>

--- a/media/css/_sass/_structure.scss
+++ b/media/css/_sass/_structure.scss
@@ -1,6 +1,7 @@
 //.presidium-container {
 //  @extend .container-fluid;
 //  margin-left: 0px;
+
 #presidium-container {
   @media (min-width: $grid-float-breakpoint) {
     margin-left: 260px;
@@ -100,6 +101,15 @@
         }
       }
       .article {
+        .placeholder {
+          width: 100%;
+          display: flex;
+
+          > .article-bar-placeholder {
+            height: 52px;
+            width: 100%;
+          }
+        }
         .article-edit-menu {
           display: flex;
           flex-direction: column;


### PR DESCRIPTION
ah-97 | add placeholder for article feedback bar to prevent jumping when presidium js components are injected on page load 