### PR TITLE
SPP-1118 | Added regex to filter/remove tags from searchmap.json

### DIFF
--- a/src/searchmap.js
+++ b/src/searchmap.js
@@ -25,9 +25,9 @@ const SearchMap = function(conf, structure) {
 SearchMap.prototype.addArticle = function(article) {
 	let stripped = String(this.stripper.processSync(article.content));
 
-	// Clear the contents of any `if` and `comment` tags
+	// Clear the contents of any `if`, `for` and `comment` tags
 	// Remove other tags but leave their contents
-	const tagsRegExp = /{% if.*?endif %}|{% comment.*?endcomment %}|{%[^{}]*%}/gms;
+	const tagsRegExp = /{% if.*?endif %}|{% for.*?endfor %}|{% comment.*?endcomment %}|{%[^{}]*%}/gms;
 	stripped = stripped.replace(tagsRegExp, '');
 
 	this.articles.push({

--- a/src/searchmap.js
+++ b/src/searchmap.js
@@ -23,7 +23,12 @@ const SearchMap = function(conf, structure) {
 };
 
 SearchMap.prototype.addArticle = function(article) {
-	const stripped = String(this.stripper.processSync(article.content));
+	let stripped = String(this.stripper.processSync(article.content));
+
+	// Clear the contents of any `if` and `comment` tags
+	// Remove other tags but leave their contents
+	const tagsRegExp = /{% if.*?endif %}|{% comment.*?endcomment %}|{%[^{}]*%}/gms;
+	stripped = stripped.replace(tagsRegExp, '');
 
 	this.articles.push({
 		id: article.id,


### PR DESCRIPTION
Ticket: https://spandigital.atlassian.net/browse/SPP-1118
Added regex to remove visible markdown/liquid template tags from `searchmap.json`.

`if` statements are removed entirely.
`comments` are removed entirely.
Other tags are removed but their content is left intact (e.g. `{% raw %} keep {% endraw %}` )

Here is a link for testing the various cases: https://regex101.com/r/55LFnv/7